### PR TITLE
Respond to RenderSizeChanged event on Dispatcher using Background priority

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFCanvas.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFCanvas.cs
@@ -587,7 +587,7 @@ namespace HelixToolkit.Wpf.SharpDX
 
                 // Ensure that at least every other cycle is done at DispatcherPriority.Render.
                 // Uncomment if animation stutters, but no need as far as I can see.
-                this.lastRenderingDuration = TimeSpan.Zero;
+                // this.lastRenderingDuration = TimeSpan.Zero;
             }
 
             // If rendering took too long last time...

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFCanvas.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFCanvas.cs
@@ -161,8 +161,8 @@ namespace HelixToolkit.Wpf.SharpDX
             this.Loaded += this.OnLoaded;
             this.Unloaded += this.OnUnloaded;
             this.ClearColor = global::SharpDX.Color.Gray;
-            this.IsShadowMapEnabled = false;            
-            this.IsMSAAEnabled = true;            
+            this.IsShadowMapEnabled = false;
+            this.IsMSAAEnabled = true;
         }
 
         /// <summary>
@@ -587,7 +587,7 @@ namespace HelixToolkit.Wpf.SharpDX
 
                 // Ensure that at least every other cycle is done at DispatcherPriority.Render.
                 // Uncomment if animation stutters, but no need as far as I can see.
-                // this.lastRenderingDuration = TimeSpan.Zero;
+                this.lastRenderingDuration = TimeSpan.Zero;
             }
 
             // If rendering took too long last time...
@@ -632,29 +632,40 @@ namespace HelixToolkit.Wpf.SharpDX
             this.lastRenderingDuration = this.renderTimer.Elapsed - t0;
         }
 
+        private bool queued = false;
+
         /// <summary>
         /// 
         /// </summary>
         /// <param name="sizeInfo"></param>
         protected override void OnRenderSizeChanged(SizeChangedInfo sizeInfo)
         {
-            if (this.surfaceD3D != null)
+            if (queued) return;
+
+            queued = true;
+
+            Dispatcher.BeginInvoke(DispatcherPriority.Background, (Action)(() =>
             {
-#if DEFERRED
-                if (this.RenderTechnique == Techniques.RenderDeferred)
-                {
-                    this.deferredRenderer.InitBuffers(this, Format.R32G32B32A32_Float);
-                }
-                if (this.RenderTechnique == Techniques.RenderGBuffer)
-                {
-                    this.deferredRenderer.InitBuffers(this, Format.B8G8R8A8_UNorm);
-                }
-#endif
-                this.CreateAndBindTargets();
-                this.SetDefaultRenderTargets();
-                this.InvalidateRender();
-            }
-            base.OnRenderSizeChanged(sizeInfo);
+
+                    if (this.surfaceD3D != null)
+                    {
+        #if DEFERRED
+                        if (this.RenderTechnique == Techniques.RenderDeferred)
+                        {
+                            this.deferredRenderer.InitBuffers(this, Format.R32G32B32A32_Float);
+                        }
+                        if (this.RenderTechnique == Techniques.RenderGBuffer)
+                        {
+                            this.deferredRenderer.InitBuffers(this, Format.B8G8R8A8_UNorm);
+                        }
+        #endif
+                        this.CreateAndBindTargets();
+                        this.SetDefaultRenderTargets();
+                        this.InvalidateRender();
+                    }
+
+                queued = false;
+            }));
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose

This reduces the rate at which we call the RenderSizeChanged event.  Surprisingly, this greatly increases the reliability of this operation at the cost of temporarily stretching the viewport while resizing.

### Declarations

- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
  - This was tested in Dynamo standalone and in Revit 2015

### Reviewers

@ikeough 

### FYIs

@jnealb